### PR TITLE
Add jest testing setup for Q3D helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "stanley",
+  "version": "1.0.0",
+  "description": "",
+  "main": "Qgis2threejs.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.5.0",
+    "jsdom": "^22.1.0"
+  }
+}

--- a/tests/q3d_helper.test.js
+++ b/tests/q3d_helper.test.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function createDummy() {
+  return new Proxy(function () {}, {
+    get: () => createDummy(),
+    apply: () => createDummy(),
+    construct: () => createDummy(),
+  });
+}
+
+describe('Q3D.E', () => {
+  beforeAll(() => {
+    const context = {
+      window: {
+        navigator: { userAgent: '' },
+        location: { href: '', search: '', hash: '' },
+        setTimeout: () => {},
+        addEventListener: () => {},
+        devicePixelRatio: 1,
+        document,
+      },
+      document,
+      CanvasRenderingContext2D: function () {},
+      THREE: new Proxy({}, { get: () => createDummy() }),
+    };
+    context.window.document = document;
+    vm.createContext(context);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'Qgis2threejs.js'), 'utf8');
+    vm.runInContext(code, context);
+    global.Q3D = context.Q3D;
+  });
+
+  test('returns element by ID', () => {
+    document.body.innerHTML = '<div id="foo"></div>';
+    const el = Q3D.E('foo');
+    expect(el).not.toBeNull();
+    expect(el.id).toBe('foo');
+  });
+});


### PR DESCRIPTION
## Summary
- add package.json with jest test runner
- add jsdom and jest as dev dependencies
- create simple Jest test for `Q3D.E`

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68408763439c8331af9da61a42caf067