### PR TITLE
Fix AR mode cleanup when camera access fails

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -204,6 +204,7 @@ function startARMode(position) {
 
     Q3D.E("view").classList.add("transparent");
   }).catch(function (error) {
+    stopARMode();             // revert settings if camera stream fails
     alert(error);
   });
 


### PR DESCRIPTION
## Summary
- reset AR mode when failing to acquire video stream

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840875544a0833195968e0e1aa22613